### PR TITLE
Non-tracked manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 .DS_Store*
 ehthumbs.db
 Thumbs.db
+
+# Manifest files generated on the fly manually (__local) or by launch scripts (__transient):
+Contents/extensions/__*.mf


### PR DESCRIPTION
I'm now generating manifests on the fly in the bash scripts. "__" prefix means generated.
